### PR TITLE
dbld: fix tarball and RPM generation

### DIFF
--- a/dbld/generate-rpm-specfile
+++ b/dbld/generate-rpm-specfile
@@ -4,15 +4,13 @@
 
 MODE=$1
 
-cp /source/packaging/rhel/* .
-
 if [ $MODE = "snapshot" ]; then
     echo "Generating snapshot version in syslog-ng.spec"
     sed -e "s/^Version: \([0-9.]\+\)/Version: $VERSION/" \
-            -e "s/^Release: \([0-9.]\+\)/Release: \1+`date +%Y%m%dT%H%M%S`/" -i syslog-ng.spec
+            -e "s/^Release: \([0-9.]\+\)/Release: \1+`date +%Y%m%dT%H%M%S`/" -i packaging/rhel/syslog-ng.spec
 elif [ $MODE = "release" ]; then
     echo "Validating that your RPM specfile matches the current version"
-    RPM_VERSION=`grep ^Version syslog-ng.spec | cut -d ' ' -f2`
+    RPM_VERSION=`grep ^Version packaging/rhel/syslog-ng.spec | cut -d ' ' -f2`
     if [ "${RPM_VERSION}" != "${VERSION}" ]; then
 	echo "The version numbers in syslog-ng.spec do not match the current version number. Cannot generate a release tarball this way"
 	exit 1

--- a/dbld/rpm
+++ b/dbld/rpm
@@ -10,10 +10,14 @@ function setup_dirs() {
 	rm -rf /build/${OS_PLATFORM} && mkdir -p /build/${OS_PLATFORM}
 }
 
-function prepare_source() {
-    # CzP's spec file expect it in the pwd
+function copy_rpm_packaging_src_files_to_build_folder() {
+    # CzP's spec file expect these files in the pwd
     # where the build was initiated
-    cp /source/packaging/rhel/syslog-ng.* /build
+    find /build/syslog-ng-${VERSION}/packaging/rhel/ -type f | grep --invert-match '\.spec$' | xargs -i cp {} /build/
+}
+
+function prepare_source() {
+    copy_rpm_packaging_src_files_to_build_folder
     cp syslog-ng-${VERSION}.tar.gz $RPMBUILD_SOURCES
 }
 


### PR DESCRIPTION
dbld builds RPM packages using the
  rpmbuild -ta syslog-ng-${VERSION}.tar.gz
command, which searches for an RPM .spec file inside the tarball.

This means, copying the spec file next to the tarball is unnecessary.

Previously, the tarball also contained 2 spec files:
 - the original in packaging/rhel
 - a modified version of packaging/rhel that was placed in the source root
   directory

Unfortunately, rpmbuild found the one inside packaging/rhel, so copying
the spec file into the source root folder also seems unnecessary.

Signed-off-by: László Várady <laszlo.varady@protonmail.com>