### PR TITLE
Rpm missing files

### DIFF
--- a/packaging/rhel/syslog-ng.spec
+++ b/packaging/rhel/syslog-ng.spec
@@ -503,6 +503,7 @@ fi
 %{_mandir}/man1/loggen.1*
 %{_mandir}/man1/pdbtool.1*
 %{_mandir}/man1/dqtool.1*
+%{_mandir}/man1/persist-tool.1*
 %{_mandir}/man1/syslog-ng-debun.1*
 %{_mandir}/man1/syslog-ng-ctl.1*
 %{_mandir}/man5/syslog-ng.conf.5*

--- a/packaging/rhel/syslog-ng.spec
+++ b/packaging/rhel/syslog-ng.spec
@@ -270,6 +270,15 @@ Requires: %{name}%{?_isa} = %{version}-%{release}
 %description http
 This module supports the HTTP destination.
 
+%package azure-auth-header
+Summary: Azure auth header support for %{name}
+Group: Development/Libraries
+Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: %{name}-http%{?_isa} = %{version}-%{release}
+
+%description azure-auth-header
+This module generates authorization header for applications connecting to Azure.
+
 %package python
 Summary:        Python destination support for syslog-ng
 Group:          System/Libraries
@@ -561,6 +570,9 @@ fi
 
 %files http
 %{_libdir}/%{name}/libhttp.so
+
+%files azure-auth-header
+%{_libdir}/%{name}/libazure-auth-header.so
 
 %files python
 %{_libdir}/%{name}/python/syslogng-1.0-py%{py_ver}.egg-info


### PR DESCRIPTION
Note that I've added `azure-auth-header` as a new "package".

We should ask @czanik if he's OK with it. `azure-auth-header` depends on the `http` module, but I didn't want to add it to the http module, because `azure-auth-header` is a module for a very specific use-case.